### PR TITLE
Add workaround for compatibility with zope.i18nmessageid 7.0

### DIFF
--- a/Products/validation/i18n.py
+++ b/Products/validation/i18n.py
@@ -21,6 +21,15 @@ def recursiveTranslate(message, **kwargs):
     if map:
         for key in map.keys():
             if isinstance(map[key], Message):
-                map[key] = translate(map[key], context=request)
+                try:
+                    map[key] = translate(map[key], context=request)
+                except TypeError:
+                    # In zope.i18nmessageid 7.0+ the mapping is an immutable
+                    # 'mappingproxy' due to some C changes for Python 3.13
+                    # support.  Without further investigation I don't know
+                    # if this is properly fixable or even if recursiveTranslate
+                    # is no longer needed.  For now work around it:
+                    # leave this part untranslated.
+                    break
 
     return translate(message, context=request)

--- a/news/70.bugfix
+++ b/news/70.bugfix
@@ -1,0 +1,4 @@
+Add workaround for compatibility with ``zope.i18nmessageid`` 7.0+ (Zope 5.11).
+This would throw a TypeError in our ``recursiveTranslate`` function.
+For now work around it: leave the recursive parts untranslated.
+[maurits]


### PR DESCRIPTION
This is for Zope 5.11 which I want to add in Plone 6.0.

This would throw a TypeError in our `recursiveTranslate` function. For now work around it: leave the recursive parts untranslated.

Sample test failure:

```
Error in test test_isDecimal (Products.validation.tests.test_validation.TestValidation.test_isDecimal)
Traceback (most recent call last):
  File "/Users/maurits/.pyenv/versions/3.12.8/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/Users/maurits/.pyenv/versions/3.12.8/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
  File "/Users/maurits/.pyenv/versions/3.12.8/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
  File "/Users/maurits/community/plone-coredev/6.0/src/Products.validation/Products/validation/tests/test_validation.py", line 62, in test_isDecimal
    v("NaN"), "Validation failed(isDecimal): 'NaN' is not a decimal number."
  File "/Users/maurits/community/plone-coredev/6.0/src/Products.validation/Products/validation/validators/RegexValidator.py", line 74, in __call__
    return recursiveTranslate(msg, **kwargs)
  File "/Users/maurits/community/plone-coredev/6.0/src/Products.validation/Products/validation/i18n.py", line 24, in recursiveTranslate
    map[key] = translate(map[key], context=request)
TypeError: 'mappingproxy' object does not support item assignment
```

A proper fix would require further investigation, also into whether the affected function is actually still needed.  But I currently don't want to do that in this old package.  Core Plone does not use it.  But in the coredev buildout on 6.0 its tests are still run.  And this may affect `collective.z3cform` which uses it.  I did not check.