### PR TITLE
Remove unneeded code from recursiveTranslate

### DIFF
--- a/Products/validation/i18n.py
+++ b/Products/validation/i18n.py
@@ -1,5 +1,4 @@
 from zope.i18n import translate
-from zope.i18nmessageid import Message
 from zope.i18nmessageid import MessageFactory
 
 
@@ -12,15 +11,15 @@ def safe_unicode(value):
 
 def recursiveTranslate(message, **kwargs):
     """translates also the message mappings before translating the message.
+
     if kwargs['REQUEST'] is None, return the message untranslated
+
+    Actually, recursive translation has been built into zope.i18n 3.5.0,
+    which was already released in 2008.  See
+    https://github.com/zopefoundation/zope.i18n/blob/master/CHANGES.rst#350-2008-07-10
+
+    So we can simply call the translate function.
+    This avoids a TypeError in Zope 5.11+, as `map[key]` is immutable there.
     """
-
     request = kwargs.get("REQUEST", None)
-
-    map = message.mapping
-    if map:
-        for key in map.keys():
-            if isinstance(map[key], Message):
-                map[key] = translate(map[key], context=request)
-
     return translate(message, context=request)

--- a/news/70.bugfix
+++ b/news/70.bugfix
@@ -1,0 +1,3 @@
+Remove unneeded code from ``recursiveTranslate`` that broke with latest Zope 5.11.
+``zope.i18n`` already supports recursive translation out of the box since 2008.
+[maurits]


### PR DESCRIPTION
This code broke with latest Zope 5.11.
``zope.i18n`` already supports recursive translation out of the box since 2008.

See https://github.com/plone/Products.validation/pull/14#discussion_r1878046252.  This replaces that PR.

For testing this, I used collective.easyform.  In a form I added an integer field with a RangeValidator.  Then I edited the RangeValidator code to insert a random existing Message from the plone domain into the validation error.  And this showed up translated in Dutch:

![Screenshot 2024-12-10 at 13 54 47](https://github.com/user-attachments/assets/cdb603e8-0f66-4f02-bfa1-e301376801b5)
